### PR TITLE
Property self loop enabled

### DIFF
--- a/frontend/src/app/editbox/editbox.component.html
+++ b/frontend/src/app/editbox/editbox.component.html
@@ -129,7 +129,7 @@
               <mat-form-field class="class-dropdown">
                 <mat-select placeholder="Range" formControlName="range" required>
                   <ng-container *ngFor="let c of rangeOptions | async">
-                    <mat-option [value]="c._id" *ngIf="c._id != selectedClassID">
+                    <mat-option [value]="c._id" >
                       {{ c.name }}
                     </mat-option>
                   </ng-container>

--- a/frontend/src/app/editbox/editbox.component.ts
+++ b/frontend/src/app/editbox/editbox.component.ts
@@ -139,11 +139,9 @@ export class EditboxComponent implements OnInit, OnChanges {
   }
 
   addProperty(formDirective: FormGroupDirective) {
-    if (this.selectedClassID !== this.formProp.value.range) {
       this.vocabService.addProperty(this.selectedClassID, this.formProp.value.name, this.formProp.value.description, this.formProp.value.URI, this.formProp.value.range);
       formDirective.resetForm();
       this.formProp.reset()
-    }
   }
 
   toggleEdit() {


### PR DESCRIPTION
enabled self-loop with a similar strategy for when multiple, that is representing with single arc but appending the property name with pipe '|'